### PR TITLE
changed some of http:// to https://

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -6,8 +6,8 @@
   
       <title>&lt;web-map&gt; Element Proposal</title>
   
-  <link class="required" rel="stylesheet" href="http://www.w3.org/StyleSheets/TR/w3c-unofficial.css" type="text/css"/>
-  <link rel="stylesheet" type="text/css" href="http://www.w3.org/StyleSheets/TR/w3c-tr.css" />
+  <link class="required" rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/w3c-unofficial.css" type="text/css"/>
+  <link rel="stylesheet" type="text/css" href="https://www.w3.org/StyleSheets/TR/w3c-tr.css" />
   <style>
         .content { background-image: none; }    
         h5 { position: relative; z-index: 3; }
@@ -63,8 +63,8 @@ dl.domintro {padding: 0.5em 1em; border: none; background:#E9FBE9; border: 1px s
        td > .example:only-child { margin: 0 0 0 0.1em; }
        dt, dfn { font-weight: bold; font-style: normal; }
   </style>
-  <script src="http://maps4html.github.io/Web-Map-Custom-Element/bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
-  <link rel="import" href="http://maps4html.github.io/Web-Map-Custom-Element/web-map.html">
+  <script src="https://maps4html.github.io/Web-Map-Custom-Element/bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+  <link rel="import" href="https://maps4html.github.io/Web-Map-Custom-Element/web-map.html">
 
 </head>
 <body>
@@ -80,7 +80,7 @@ dl.domintro {padding: 0.5em 1em; border: none; background:#E9FBE9; border: 1px s
 
 <dl>
   <dt>This version:</dt>
-  <dd><a href="http://maps4html.github.io/HTML-Map-Element/spec/">http://maps4html.github.io/HTML-Map-Element/spec/</a></dd>
+  <dd><a href="https://maps4html.github.io/HTML-Map-Element/spec/">https://maps4html.github.io/HTML-Map-Element/spec/</a></dd>
   
   <dt>Latest version:</dt>
   <dd><a href="https://github.com/Maps4HTML/HTML-Map-Element">https://github.com/Maps4HTML/HTML-Map-Element</a></dd>
@@ -91,7 +91,7 @@ dl.domintro {padding: 0.5em 1em; border: none; background:#E9FBE9; border: 1px s
   <dt>Editors:</dt>
 	<dd><em>Peter Rushforth</em>, Natural Resources Canada</dd>
   <dt>Authors:</dt>
-  <dd><em><a href="http://www.w3.org/community/maps4html/">Maps for HTML Community Group</a></em>.</dd>
+  <dd><em><a href="https://www.w3.org/community/maps4html/">Maps for HTML Community Group</a></em>.</dd>
 </dl>
 
 
@@ -672,9 +672,9 @@ can be optionally designated as hyperlinks to be selected by the user.</p>
 
     <dt id="ref-MapML"><strong class="normref">[MapML]</strong></dt>
     <dd>
-      <cite><a href="http://maps4html.github.io/MapML/spec/">Map Markup Language</a></cite>,
+      <cite><a href="https://maps4html.github.io/MapML/spec/">Map Markup Language</a></cite>,
       Maps For HTML Community Group, July 14, 2015.
-      <br>Available at http://maps4html.github.io/MapML/spec/.
+      <br>Available at https://maps4html.github.io/MapML/spec/.
     </dd>
 
     <dt id="ref-RNG"><strong class="normref">[RELAXNG]</strong></dt>


### PR DESCRIPTION
mostly to avoid browsers blocking 'mixed active content'

http://maps4html.github.io/HTML-Map-Element/spec/ breaks for me in both Firefox and Chromium
https://elf-pavlik.github.io/HTML-Map-Element/spec/ with this patch works just fine