### PR TITLE
Make (the latest version) of HTML-Map-Element spec more readable

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en"><head>
-      <meta charset="UTF-8">
-      <title>HTML &lt;map&gt; Element Proposal</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>HTML &lt;map&gt; Element Proposal</title>
   
   <link class="required" rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/w3c-unofficial.css" type="text/css"/>
   <link rel="stylesheet" type="text/css" href="https://www.w3.org/StyleSheets/TR/w3c-tr.css" />
@@ -60,7 +61,9 @@ dl.domintro {padding: 0.5em 1em; border: none; background:#E9FBE9; border: 1px s
        td > .example:only-child { margin: 0 0 0 0.1em; }
        dt, dfn { font-weight: bold; font-style: normal; }
   </style>
-
+  <style>
+    *,::after,::before{box-sizing: inherit;}.element::before{box-sizing: initial;width: 0.95em;left: -1.18em;}html{box-sizing: border-box; overflow-wrap: break-word;}body{width: 100%; max-width: 50em; margin: 0 auto;line-height: 1.5;padding: 2rem 2.5em;}html, body{overflow-x: hidden;}table{overflow: auto; display: block;}th:first-child,td:first-child{border-left: 0;}th:last-child,td:last-child{border-right: 0;}.content img{width: 100%;max-width: 100%;height: auto;}.example{overflow-x: hidden;padding: 1em 0 0 0 !important;}.example > *,.example::before{padding-left: 1em !important;padding-right: 1em !important;}dd{margin-left: 0;}pre{overflow: auto;margin-left: initial;}dl.domintro::before{display: table; margin: -1em -0.5em .5em auto;}@media (max-width: 1024px){body{padding-right: 1em;}.toc{padding-left: .5rem;}#google_translate_element [id*="targetLanguage"]{display: block !important;}}pre.idl::before{position:initial;display:block;padding:.3em;width:2.25em;margin:0 .5em .5em 0;background-color:#F4F4FA;}
+  </style>
 </head>
 <body>
 <div class="content">


### PR DESCRIPTION
The https://github.com/Maps4HTML/HTML-Map-Element/pull/19 PR did not update the **latest** spec, <s>this fixes</s> does this fix that? I'm confused that they're in different branches..