### PR TITLE
Point links to HTTPS

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -99,7 +99,7 @@ dl.domintro {padding: 0.5em 1em; border: none; background:#E9FBE9; border: 1px s
 </dl>
 
 
-<p>Copyright © 2015-2019 the Contributors to the HTML &lt;map&gt; Element proposal, published by the  <a href="https://www.w3.org/community/maps4html/">Maps for HTML Community Group</a> under the <a href="http://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.
+<p>Copyright © 2015-2019 the Contributors to the HTML &lt;map&gt; Element proposal, published by the  <a href="https://www.w3.org/community/maps4html/">Maps for HTML Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.
 </p>
 </div>
 
@@ -234,10 +234,10 @@ and should only depend on Web standards, including Uniform Resource Identifiers,
 	<h2 id="conformance">2. Conformance</h2>
 	<p>This section is normative.</p>
 	
-	<p>Within this specification, the key words "MUST, "MUST NOT", "REQUIRED, 
-          "SHALL, "SHALL NOT, "SHOULD, "SHOULD NOT", "RECOMMENDED, "MAY", and 
+	<p>Within this specification, the key words "MUST", "MUST NOT", "REQUIRED", 
+          "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and 
           "OPTIONAL" are to be interpreted as described in 
-          <a target="_blank" href="http://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a> [<a href="#ref-RFC2119">RFC2119</a>].  
+          <a target="_blank" href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a> [<a href="#ref-RFC2119">RFC2119</a>].  
           However, for readability, these words do not necessarily appear in uppercase in this specification.</p>
 
 </div>
@@ -296,7 +296,7 @@ and should only depend on Web standards, including Uniform Resource Identifiers,
 
   <p><strong>Implementation commitments</strong>:  </p>
   <p>The <a href="#ref-Web-Map-Custom-Element">customized built-in <code>map</code> element</a> was built and is maintained by the Maps for HTML Community Group.</p>
-  <p>Map Markup Language <a target="_blank" href="http://geogratis.gc.ca/mapml/en/">services</a> are provided by Natural Resources Canada as part of the
+  <p>Map Markup Language <a target="_blank" href="https://geogratis.gc.ca/mapml/en/">services</a> are provided by Natural Resources Canada as part of the
   Canadian Geospatial Data Infrastructure.</p>
   <p>The reader is requested to contact the <a href="mailto:public-maps4html@w3.org">editor</a> with any known implementations of
   Map Markup Language or other implemented support for this proposal.</p>
@@ -627,7 +627,7 @@ can be optionally designated as hyperlinks to be selected by the user.</p>
    <p>This map can be created with the following markup:</p>
 
    <pre>&lt;map zoom="11" lat="48.85591" lon="2.3469543" width="640" height="300"&gt;
-   &lt;layer label="Open Street Map" src="http://example.com/mapml/osm/" checked&gt;&lt;/layer&gt;
+   &lt;layer label="Open Street Map" src="https://example.com/mapml/osm/" checked&gt;&lt;/layer&gt;
 &lt;/map&gt;
 </pre>
    
@@ -650,8 +650,8 @@ can be optionally designated as hyperlinks to be selected by the user.</p>
      }
    &lt;/style&gt;
   &lt;map zoom="15" lat="45.398043" lon="-75.70683" width="640" height="300" projection="CBMTILE"&gt;
-    &lt;layer label="Canada Base Map" src="http://example.com/mapml/cbmt/" checked&gt;&lt;/layer&gt;
-    &lt;layer label="CanVec+ 031G" src="http://example.com/mapml/canvec/50k/features/" class="transparency"&gt;&lt;/layer&gt;
+    &lt;layer label="Canada Base Map" src="https://example.com/mapml/cbmt/" checked&gt;&lt;/layer&gt;
+    &lt;layer label="CanVec+ 031G" src="https://example.com/mapml/canvec/50k/features/" class="transparency"&gt;&lt;/layer&gt;
   &lt;/map&gt;
 </pre>
    
@@ -707,9 +707,9 @@ can be optionally designated as hyperlinks to be selected by the user.</p>
 
     <dt id="ref-RFC2119"><strong class="normref">[RFC2119]</strong></dt>
     <dd>
-      <cite><a target="_blank" href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></cite>,
+      <cite><a target="_blank" href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></cite>,
       S. Bradner, March 1997.
-      <br>Available at http://tools.ietf.org/html/rfc2119.
+      <br>Available at https://tools.ietf.org/html/rfc2119.
     </dd>
 
     <dt id="ref-Web-Map-Custom-Element"><strong class="normref">[Map-Custom-Element]</strong></dt>
@@ -721,17 +721,17 @@ can be optionally designated as hyperlinks to be selected by the user.</p>
 
     <dt id="ref-MapML"><strong class="normref">[Map Markup Language]</strong></dt>
     <dd>
-      <cite><a target="_blank" href="http://maps4html.github.io/MapML/spec/">Map Markup Language</a></cite>,
+      <cite><a target="_blank" href="https://maps4html.github.io/MapML/spec/">Map Markup Language</a></cite>,
       Maps For HTML Community Group, July 14, 2015.
       <br>Available at https://maps4html.github.io/MapML/spec/.
     </dd>
 
     <dt id="ref-RNG"><strong class="normref">[RELAXNG]</strong></dt>
 <dd>
-	    <cite><a target="_blank" href="http://www.y12.doe.gov/sgml/sc34/document/0362_files/relaxng-is.pdf">Document Schema Definition Languages (DSDL) — Part 2: Regular grammar-based validation — RELAX NG, ISO/IEC FDIS 19757-2:2002(E)</a></cite>,
+	    <cite><a target="_blank" href="https://web.archive.org/web/20120619140335/http://www1.y12.doe.gov/capabilities/sgml/sc34/document/0362_files/relaxng-is.pdf">Document Schema Definition Languages (DSDL) — Part 2: Regular grammar-based validation — RELAX NG, ISO/IEC FDIS 19757-2:2002(E)</a></cite>,
 	    J. Clark, <ruby><rb xml:lang="ja" lang="ja">村田 真</rb> <rp>(</rp><rt><span class="familyname">Murata</span> M.</rt><rp>)</rp></ruby>, eds.
 	    International Organization for Standardization, 12 December 2002.
-	    <br>Available at http://www.y12.doe.gov/sgml/sc34/document/0362_files/relaxng-is.pdf.
+	    <br>Available at https://web.archive.org/web/20120619140335/http://www1.y12.doe.gov/capabilities/sgml/sc34/document/0362_files/relaxng-is.pdf.
 	  </dd>	</dl>
 
 	<h3 id="informrefs">8.2. Informative References</h3>
@@ -743,8 +743,8 @@ can be optionally designated as hyperlinks to be selected by the user.</p>
       C. McCormack, ed.
       World Wide Web Consortium, <span class="wip">work in progress</span>, 19 December 2008.
       <br>This edition of WebIDL is https://www.w3.org/TR/2008/WD-WebIDL-20081219/.
-      <br>The <a target="_blank" href="http://dev.w3.org/2006/webapi/WebIDL/">latest edition of WebIDL</a> is available at
-      http://dev.w3.org/2006/webapi/WebIDL/.
+      <br>The <a target="_blank" href="https://www.w3.org/TR/WebIDL/">latest edition of WebIDL</a> is available at
+      https://www.w3.org/TR/WebIDL/.
     </dd>
 
 	</dl>


### PR DESCRIPTION
Replace all occurrences of http:// links with https://.

Also update https://www.y12.doe.gov/sgml/sc34/document/0362_files/relaxng-is.pdf, with a web.archive.org link (as I wasn't able to find any other replacement) https://web.archive.org/web/20120619140335/http://www1.y12.doe.gov/capabilities/sgml/sc34/document/0362_files/relaxng-is.pdf
Edit: Perhaps you'd use the [ISO/IEC 19757-2:2008](https://standards.iso.org/ittf/PubliclyAvailableStandards/c052348_ISO_IEC_19757-2_2008(E).zip) version downloadable in https://standards.iso.org/ittf/PubliclyAvailableStandards/index.html

Add missing double quotes `"` around keywords such as "MUST", "MUST NOT", "REQUIRED"... etc.

<hr>

Finally, as a note, the [W3C and WHATWG has agreed](https://www.w3.org/blog/news/archives/7753) to move the HTML spec to WHATWG and as such the attribution in the informative references would need to change I think (this applies to the MapML spec too):

> [HTML]
> [HTML5 A vocabulary and associated APIs for HTML and XHTML](https://www.w3.org/TR/html/). I. Hickson, R. Berjon, S. Faulkner, T. Leithead E. Doyle Navara, E. O'Connor, S. Pfeiffer, eds. World Wide Web Consortium, 28 October 2014.

But I'm not sure to what...
