### PR TITLE
Add `referrerpolicy` to `<layer>`'s content attributes

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -462,6 +462,7 @@ interface <dfn id="htmlmapelement">HTMLMapElement</dfn> : <a target="_blank" hre
   <em> readonly attribute boolean <a href="#attr-layer-disabled">disabled</a>;</em>
   <em>          attribute boolean <a href="#attr-layer-hidden">hidden</a>;</em>
   <em> readonly attribute <a href="#legendlink">LegendLink[]</a> legendLinks;</em>
+  <em>          attribute DOMString <a href="#attr-layer-referrerpolicy">referrerpolicy</a>;</em>
 };
 
 interface <dfn id="legendlink">LegendLink</dfn> {

--- a/spec/index.html
+++ b/spec/index.html
@@ -446,6 +446,7 @@ interface <dfn id="htmlmapelement">HTMLMapElement</dfn> : <a target="_blank" hre
    <dd id="attr-layer-label"><em><code><a href="#attr-layer-label">label</a></code> - String label for the layer in the layer control, if displayed</em></dd>
    <dd id="attr-layer-checked"><em><code><a href="#attr-layer-checked">checked</a></code> - Layer on/off status</em></dd>
    <dd id="attr-layer-hidden"><em><code><a href="#attr-layer-hidden">hidden</a></code> - Visibility status of the layer in the layer control</em></dd>
+   <dd id="attr-layer-referrerpolicy"><em><code><a href="#attr-layer-referrerpolicy">referrerpolicy</a></code> - <a href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy">Referrer policy</a> for <a href="https://fetch.spec.whatwg.org/#concept-fetch">fetches</a> initiated by the element</em></dd>
   <dt><span>Tag omission in text/html</span>:</dt>
    <dd>Neither tag is omissible</dd>
    <dt>Allowed <a target="_blank" href="https://www.w3.org/TR/2014/REC-html5-20141028/dom.html#aria-role-attribute">ARIA role attribute</a> values:</dt>


### PR DESCRIPTION
Closes #23.

@prushforth does this look good to you?

I noticed the way the IDL attributes are defined is different from e.g. how WHATWG HTML does it for iframe: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element:dom-iframe-referrerpolicy - the IDL attributes have links to definitions of how they reflect a particular content attribute.

I dug into this a bit and I found that the HTML Portals spec got a request to [separate src IDL and content attributes](https://github.com/WICG/portals/issues/72).
But changing that now to include explicit definitions of each IDL attribute separate from content attributes means we should probably do that for everything, and that's perhaps something we can do later as part of (or after) the [merge of this spec into MapML](https://github.com/Maps4HTML/MapML/issues/55)? This way we can just get the attribute in this spec for now...?